### PR TITLE
Update living_Quarters.py

### DIFF
--- a/living_Quarters.py
+++ b/living_Quarters.py
@@ -21,3 +21,5 @@ while True:
     trunk = ["Notebook", "Pen","Dagger"]
     
     continue
+    
+inventory.extend(trunk)


### PR DESCRIPTION
Adding trunk inventory to player inventory. Can we change the name of the inventory to "playerinventory"? Is that necessary?